### PR TITLE
Add ticket database and reference data

### DIFF
--- a/server/prisma/migrations/20260903011904_add_ticket_and_related_system/migration.sql
+++ b/server/prisma/migrations/20260903011904_add_ticket_and_related_system/migration.sql
@@ -1,0 +1,56 @@
+-- CreateEnum
+CREATE TYPE "Priority" AS ENUM ('LOW', 'MEDIUM', 'HIGH');
+
+-- CreateEnum
+CREATE TYPE "TicketStatus" AS ENUM ('NEW', 'OPEN', 'IN_PROGRESS', 'RESOLVED', 'CLOSED', 'CANCELLED');
+
+-- CreateTable
+CREATE TABLE "RelatedSystem" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "RelatedSystem_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Ticket" (
+    "id" SERIAL NOT NULL,
+    "ticketNumber" TEXT NOT NULL,
+    "requesterId" INTEGER NOT NULL,
+    "categoryId" INTEGER NOT NULL,
+    "relatedSystemId" INTEGER NOT NULL,
+    "summary" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "requestedPriority" "Priority" NOT NULL,
+    "itPriority" "Priority",
+    "status" "TicketStatus" NOT NULL DEFAULT 'NEW',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Ticket_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RelatedSystem_name_key" ON "RelatedSystem"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Ticket_ticketNumber_key" ON "Ticket"("ticketNumber");
+
+-- CreateIndex
+CREATE INDEX "Ticket_requesterId_idx" ON "Ticket"("requesterId");
+
+-- CreateIndex
+CREATE INDEX "Ticket_status_idx" ON "Ticket"("status");
+
+-- CreateIndex
+CREATE INDEX "Ticket_categoryId_idx" ON "Ticket"("categoryId");
+
+-- AddForeignKey
+ALTER TABLE "Ticket" ADD CONSTRAINT "Ticket_requesterId_fkey" FOREIGN KEY ("requesterId") REFERENCES "DevelopmentRequester"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Ticket" ADD CONSTRAINT "Ticket_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "Category"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Ticket" ADD CONSTRAINT "Ticket_relatedSystemId_fkey" FOREIGN KEY ("relatedSystemId") REFERENCES "RelatedSystem"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -25,6 +25,7 @@ model Category {
   id        Int      @id @default(autoincrement())
   name      String   @unique
   createdAt DateTime @default(now())
+  tickets   Ticket[]
 }
 //lab2 issue2
 model DevelopmentRequester {
@@ -33,4 +34,76 @@ model DevelopmentRequester {
   email     String   @unique
   isActive  Boolean  @default(true)
   createdAt DateTime @default(now())
+  tickets   Ticket[]
+}
+
+// ---------------------------------------------------------------------------
+// Lab 2 Issue 3 — Ticket Database and Reference Data
+// Adds RelatedSystem (reference data) and Ticket (the core entity), plus
+// the Priority/TicketStatus enums. Attachment is intentionally NOT added
+// here — that belongs to Issue 6 (Ticket Detail + Attachments).
+// ---------------------------------------------------------------------------
+
+enum Priority {
+  LOW
+  MEDIUM
+  HIGH
+}
+
+// BR-02: a new Ticket always starts at NEW. The later values exist now so
+// Lab 3+ workflow features don't require another migration (spec.md §11).
+enum TicketStatus {
+  NEW
+  OPEN
+  IN_PROGRESS
+  RESOLVED
+  CLOSED
+  CANCELLED
+}
+
+model RelatedSystem {
+  id        Int      @id @default(autoincrement())
+  name      String   @unique
+  createdAt DateTime @default(now())
+
+  tickets   Ticket[]
+}
+
+model Ticket {
+  id                Int           @id @default(autoincrement())
+
+  // BR-01: backend-generated, unique, human-readable (e.g. TKT-2026-000123).
+  // The generation logic itself is implemented in Issue 4 (Ticket Creation);
+  // this column just enforces uniqueness at the database level.
+  ticketNumber      String        @unique
+
+  requesterId       Int
+  requester         DevelopmentRequester @relation(fields: [requesterId], references: [id])
+
+  categoryId        Int
+  category          Category      @relation(fields: [categoryId], references: [id])
+
+  relatedSystemId   Int
+  relatedSystem     RelatedSystem @relation(fields: [relatedSystemId], references: [id])
+
+  summary           String
+  description       String
+  requestedPriority Priority
+
+  // BR-02: unset until IT Staff triage in a later sprint (out of scope here).
+  itPriority        Priority?
+
+  status            TicketStatus  @default(NEW)
+
+  createdAt         DateTime      @default(now())
+  updatedAt         DateTime      @updatedAt
+
+  // TODO(Lab 2 Issue 6): add `attachments Attachment[]` once the Attachment
+  // model exists — do not add it here, it will fail to compile until then.
+
+  // spec.md §7 — indexes supporting ownership checks, status filtering,
+  // and category filtering on the My Tickets list (Issue 5).
+  @@index([requesterId])
+  @@index([status])
+  @@index([categoryId])
 }

--- a/server/prisma/seed.ts
+++ b/server/prisma/seed.ts
@@ -30,6 +30,26 @@ async function main() {
       create: requester,
     });
   }
+  // Lab 2 Issue 3 — Related Systems (handout §5.3: at least six).
+  // Upsert by name so re-running is idempotent.
+  const relatedSystemNames = [
+    "Email",
+    "Campus Wi-Fi",
+    "VPN",
+    "LEB2 App",
+    "Grade Submission App",
+    "Printer",
+    "Corporate Laptop",
+  ];
+
+  for (const name of relatedSystemNames) {
+    await prisma.relatedSystem.upsert({
+      where: { name },
+      update: {},
+      create: { name },
+    });
+  }
+  
 
   console.log("Seed complete: categories and development requesters.");
 }


### PR DESCRIPTION
## Summary

Implements **Lab 2 – Issue 3: Ticket Database and Reference Data**.

## Changes

* Added the `RelatedSystem` model and reference data.
* Added the `Ticket` model with requester, category, and related system relationships.
* Added the `Priority` and `TicketStatus` enums.
* Added database indexes for requester, status, and category.
* Updated `seed.ts` with 7 Related Systems, upserted by name for safe re-running.
* Added the Prisma migration for the new Ticket and RelatedSystem database structure.

## Notes

* `Attachment` is intentionally **not included** because it is part of Issue 6. Referencing it here would fail until the Attachment model is added.
* Ticket Number **generation logic** (BR-01) is not included in this issue. The `ticketNumber` field is present and unique, while the generate-on-create logic belongs to Issue 4 (Ticket Creation).
* No API routes or tests are included in this PR by design. `GET /api/related-systems` and ticket-creation tests are scoped to Issue 4, where they are consumed.

## Testing

* `npx prisma migrate dev` completed successfully.
* `npx prisma db seed` was run twice to confirm idempotency with no duplicate rows.
* `npx tsc --noEmit` passes with no Prisma Client errors after `prisma generate`.
