### PR TITLE
Feature/lab2 issue6 ticket detail attachments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ server/prisma/*.db
 # logs & OS
 *.log
 .DS_Store
+!server/uploads/.gitkeep
+server/uploads/*
+!server/uploads/.gitkeep

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,32 +5,47 @@ import RequesterSelection from "./pages/RequesterSelection.js";
 import HealthCheck from "./pages/HealthCheck.js";
 import TicketsPlaceholder from "./pages/TicketsPlaceholder.js";
 import CreateTicket from "./pages/CreateTicket.js";
+import TicketDetail from "./pages/TicketDetail.js";
 import AppShell from "./components/AppShell.js";
 
+// Lab 2 router shell. "/" is the Development Requester Selection screen
+// (BR-04). "/tickets" is My Tickets (Issue 5). "/tickets/new" is Create
+// Ticket (Issue 4). "/tickets/:id" is Requester Ticket Detail (Issue 6).
+// All three are gated by RequesterGuard per BR-07. "/dev-check" keeps
+// Lab 1's demo reachable. AppShell wraps everything so the Zen Green
+// header/nav (handout §8) is consistent across every screen.
 export default function App() {
   return (
     <RequesterProvider>
       <AppShell>
-      <Routes>
-        <Route path="/" element={<RequesterSelection />} />
-        <Route
-          path="/tickets"
-          element={
-            <RequesterGuard>
-              <TicketsPlaceholder />
-            </RequesterGuard>
-          }
-        />
-        <Route
-          path="/tickets/new"
-          element={
-            <RequesterGuard>
-              <CreateTicket />
-            </RequesterGuard>
-          }
-        />
-        <Route path="/dev-check" element={<HealthCheck />} />
-      </Routes>
+        <Routes>
+          <Route path="/" element={<RequesterSelection />} />
+          <Route
+            path="/tickets"
+            element={
+              <RequesterGuard>
+                <TicketsPlaceholder />
+              </RequesterGuard>
+            }
+          />
+          <Route
+            path="/tickets/new"
+            element={
+              <RequesterGuard>
+                <CreateTicket />
+              </RequesterGuard>
+            }
+          />
+          <Route
+            path="/tickets/:id"
+            element={
+              <RequesterGuard>
+                <TicketDetail />
+              </RequesterGuard>
+            }
+          />
+          <Route path="/dev-check" element={<HealthCheck />} />
+        </Routes>
       </AppShell>
     </RequesterProvider>
   );

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -167,3 +167,99 @@ export async function fetchTickets(params: TicketListParams): Promise<TicketList
   }
   return res.json();
 }
+
+// Lab 2 Issue 6 — Ticket Detail + Attachments
+
+export interface AttachmentMeta {
+  id: number;
+  fileName: string;
+  sizeBytes: number;
+  mimeType?: string;
+  isRemoved: boolean;
+  removedAt: string | null;
+  removedReason: string | null;
+  createdAt: string;
+}
+
+export interface TicketDetailData {
+  id: number;
+  ticketNumber: string;
+  requesterId: number;
+  category: string;
+  relatedSystem: string;
+  summary: string;
+  description: string;
+  requestedPriority: Priority;
+  itPriority: Priority | null;
+  currentStatus: string;
+  createdAt: string;
+  updatedAt: string;
+  attachments: AttachmentMeta[];
+}
+
+export class TicketNotFoundError extends Error {}
+
+export async function fetchTicketDetail(
+  ticketId: number,
+  requesterId: number
+): Promise<TicketDetailData> {
+  const res = await fetch(`${API_URL}/api/tickets/${ticketId}?requesterId=${requesterId}`);
+  if (res.status === 404) {
+    throw new TicketNotFoundError("TICKET_NOT_FOUND");
+  }
+  if (!res.ok) {
+    throw new Error("Failed to load ticket");
+  }
+  return res.json();
+}
+
+export class AttachmentUploadError extends Error {
+  code: string;
+  constructor(code: string) {
+    super(code);
+    this.code = code;
+  }
+}
+
+export async function uploadAttachment(
+  ticketId: number,
+  requesterId: number,
+  file: File
+): Promise<AttachmentMeta> {
+  const formData = new FormData();
+  formData.append("requesterId", String(requesterId));
+  formData.append("file", file);
+
+  const res = await fetch(`${API_URL}/api/tickets/${ticketId}/attachments`, {
+    method: "POST",
+    body: formData,
+  });
+
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({ error: "UPLOAD_FAILED" }));
+    throw new AttachmentUploadError(body.error ?? "UPLOAD_FAILED");
+  }
+  return res.json();
+}
+
+export function attachmentDownloadUrl(attachmentId: number, requesterId: number): string {
+  return `${API_URL}/api/attachments/${attachmentId}/download?requesterId=${requesterId}`;
+}
+
+export async function removeAttachment(
+  attachmentId: number,
+  requesterId: number,
+  reason: string
+): Promise<AttachmentMeta> {
+  const res = await fetch(`${API_URL}/api/attachments/${attachmentId}/remove`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ requesterId, reason }),
+  });
+
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({ error: "REMOVE_FAILED" }));
+    throw new Error(body.error ?? "REMOVE_FAILED");
+  }
+  return res.json();
+}

--- a/client/src/pages/CreateTicket.tsx
+++ b/client/src/pages/CreateTicket.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import {
   Category,
@@ -7,6 +7,8 @@ import {
   fetchCategories,
   fetchRelatedSystems,
   createTicket,
+  uploadAttachment,
+  AttachmentUploadError,
   CreateTicketValidationError,
   FieldErrors,
   Ticket,
@@ -24,12 +26,23 @@ const cardStyle: React.CSSProperties = {
   boxShadow: "0 1px 3px rgba(0,0,0,0.05)",
 };
 
-// Lab 2 Issue 4 — Ticket Creation
-// Attachments are intentionally NOT part of this screen yet — the
-// Attachment model and its upload endpoint belong to Issue 6.
+const MAX_FILES = 5;
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB, BR-22
+const ALLOWED_EXTENSIONS = [".jpg", ".jpeg", ".png", ".webp", ".pdf"];
+
+function isAllowedFile(file: File): boolean {
+  const lower = file.name.toLowerCase();
+  return ALLOWED_EXTENSIONS.some((ext) => lower.endsWith(ext));
+}
+
+// Lab 2 Issue 4 + Issue 6 — Ticket Creation with Attachments
+// Flow: create the Ticket first, then upload any selected files to it.
+// If a file upload fails, the Ticket is still saved (BR-21) — failures are
+// reported so the Requester can retry from Ticket Detail instead.
 export default function CreateTicket() {
   const { requester } = useRequester();
   const navigate = useNavigate();
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const [categories, setCategories] = useState<Category[]>([]);
   const [relatedSystems, setRelatedSystems] = useState<RelatedSystem[]>([]);
@@ -40,11 +53,14 @@ export default function CreateTicket() {
   const [requestedPriority, setRequestedPriority] = useState<Priority | "">("");
   const [summary, setSummary] = useState("");
   const [description, setDescription] = useState("");
+  const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
+  const [fileError, setFileError] = useState("");
 
   const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
   const [submitState, setSubmitState] = useState<SubmitState>("idle");
   const [submitErrorMessage, setSubmitErrorMessage] = useState("");
   const [createdTicket, setCreatedTicket] = useState<Ticket | null>(null);
+  const [attachmentFailures, setAttachmentFailures] = useState<string[]>([]);
 
   useEffect(() => {
     let cancelled = false;
@@ -65,6 +81,38 @@ export default function CreateTicket() {
     };
   }, []);
 
+  function handleFilesSelected(e: React.ChangeEvent<HTMLInputElement>) {
+    const incoming = Array.from(e.target.files ?? []);
+    setFileError("");
+
+    if (selectedFiles.length + incoming.length > MAX_FILES) {
+      setFileError(`You can attach at most ${MAX_FILES} files.`);
+      if (fileInputRef.current) fileInputRef.current.value = "";
+      return;
+    }
+
+    const invalid = incoming.find((f) => !isAllowedFile(f));
+    if (invalid) {
+      setFileError(`"${invalid.name}" isn't an allowed type (JPG, PNG, WEBP, or PDF only).`);
+      if (fileInputRef.current) fileInputRef.current.value = "";
+      return;
+    }
+
+    const tooLarge = incoming.find((f) => f.size > MAX_FILE_SIZE);
+    if (tooLarge) {
+      setFileError(`"${tooLarge.name}" is too large — 5MB maximum.`);
+      if (fileInputRef.current) fileInputRef.current.value = "";
+      return;
+    }
+
+    setSelectedFiles((prev) => [...prev, ...incoming]);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  }
+
+  function removeSelectedFile(index: number) {
+    setSelectedFiles((prev) => prev.filter((_, i) => i !== index));
+  }
+
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     if (!requester) return;
@@ -82,11 +130,25 @@ export default function CreateTicket() {
         description,
         requestedPriority: requestedPriority as Priority,
       });
+
+      // BR-21: Ticket is already saved at this point. Attachment upload
+      // failures below are reported but never roll back the Ticket.
+      const failures: string[] = [];
+      for (const file of selectedFiles) {
+        try {
+          await uploadAttachment(ticket.id, requester.id, file);
+        } catch (err) {
+          failures.push(
+            file.name + (err instanceof AttachmentUploadError ? ` (${err.code})` : "")
+          );
+        }
+      }
+
+      setAttachmentFailures(failures);
       setCreatedTicket(ticket);
       setSubmitState("success");
     } catch (err) {
-      // BR-19/BR-20: entered values are NEVER cleared on failure — we simply
-      // don't reset categoryId/relatedSystemId/summary/description here.
+      // BR-19/BR-20: entered values are NEVER cleared on failure.
       if (err instanceof CreateTicketValidationError) {
         setFieldErrors(err.fields);
         setSubmitState("idle");
@@ -112,13 +174,30 @@ export default function CreateTicket() {
           </p>
           <p className="mb-1">Ticket Date: {new Date(createdTicket.createdAt).toLocaleString()}</p>
           <p className="mb-3">Requester: {requester?.name}</p>
-          <button
-            className="btn btn-sm"
-            style={{ backgroundColor: zenGreen.primary, color: "white" }}
-            onClick={() => navigate("/tickets")}
-          >
-            Back to My Tickets
-          </button>
+
+          {attachmentFailures.length > 0 && (
+            <div className="alert alert-warning small">
+              Ticket was saved, but {attachmentFailures.length} attachment(s) failed to upload:{" "}
+              {attachmentFailures.join(", ")}. You can retry adding them from the ticket's detail
+              page.
+            </div>
+          )}
+
+          <div className="d-flex gap-2">
+            <button
+              className="btn btn-sm"
+              style={{ backgroundColor: zenGreen.primary, color: "white" }}
+              onClick={() => navigate(`/tickets/${createdTicket.id}`)}
+            >
+              View Ticket
+            </button>
+            <button
+              className="btn btn-sm btn-outline-secondary"
+              onClick={() => navigate("/tickets")}
+            >
+              Back to My Tickets
+            </button>
+          </div>
         </div>
       </div>
     );
@@ -140,29 +219,26 @@ export default function CreateTicket() {
       {refState === "ready" && (
         <div className="p-4" style={cardStyle}>
           <form onSubmit={handleSubmit} noValidate>
-            {/* System-generated / read-only fields — handout §4.4 requires
-                Ticket Number, Ticket Date, and Requester to be shown, even
-                though they're not editable here. */}
             <div
               className="row g-3 mb-4 p-3"
               style={{ backgroundColor: zenGreen.readOnlyBg, borderRadius: 6 }}
             >
-              <div className="col-md-4">
+              <div className="col-12 col-md-6 col-lg-4">
                 <label className="form-label text-muted small mb-1">Ticket Number</label>
                 <div className="form-control-plaintext">Assigned after submission</div>
               </div>
-              <div className="col-md-4">
+              <div className="col-12 col-md-6 col-lg-4">
                 <label className="form-label text-muted small mb-1">Ticket Date</label>
                 <div className="form-control-plaintext">{new Date().toLocaleDateString()}</div>
               </div>
-              <div className="col-md-4">
+              <div className="col-12 col-md-6 col-lg-4">
                 <label className="form-label text-muted small mb-1">Requester</label>
                 <div className="form-control-plaintext">{requester?.name}</div>
               </div>
             </div>
 
             <div className="row g-3 mb-3">
-              <div className="col-md-4">
+              <div className="col-12 col-md-6 col-lg-4">
                 <label className="form-label" htmlFor="category">
                   Category <span className="text-danger">*</span>
                 </label>
@@ -186,7 +262,7 @@ export default function CreateTicket() {
                 )}
               </div>
 
-              <div className="col-md-4">
+              <div className="col-12 col-md-6 col-lg-4">
                 <label className="form-label" htmlFor="relatedSystem">
                   Related System <span className="text-danger">*</span>
                 </label>
@@ -210,7 +286,7 @@ export default function CreateTicket() {
                 )}
               </div>
 
-              <div className="col-md-4">
+              <div className="col-12 col-md-6 col-lg-4">
                 <label className="form-label" htmlFor="requestedPriority">
                   Requested Priority <span className="text-danger">*</span>
                 </label>
@@ -264,6 +340,45 @@ export default function CreateTicket() {
               />
               {fieldErrors.description && (
                 <div className="invalid-feedback d-block">{fieldErrors.description}</div>
+              )}
+            </div>
+
+            <div className="mb-4">
+              <label className="form-label" htmlFor="attachments">
+                Attachments (optional, up to {MAX_FILES}, JPG/PNG/WEBP/PDF, 5MB each)
+              </label>
+              <input
+                ref={fileInputRef}
+                id="attachments"
+                type="file"
+                className="form-control"
+                accept=".jpg,.jpeg,.png,.webp,.pdf"
+                multiple
+                onChange={handleFilesSelected}
+                disabled={selectedFiles.length >= MAX_FILES}
+              />
+              {fileError && <div className="text-danger small mt-1">{fileError}</div>}
+
+              {selectedFiles.length > 0 && (
+                <ul className="list-group mt-2">
+                  {selectedFiles.map((f, i) => (
+                    <li
+                      key={`${f.name}-${i}`}
+                      className="list-group-item d-flex justify-content-between align-items-center py-1"
+                    >
+                      <span className="small">
+                        {f.name} <span className="text-muted">({(f.size / 1024).toFixed(0)} KB)</span>
+                      </span>
+                      <button
+                        type="button"
+                        className="btn btn-sm btn-outline-danger py-0"
+                        onClick={() => removeSelectedFile(i)}
+                      >
+                        Remove
+                      </button>
+                    </li>
+                  ))}
+                </ul>
               )}
             </div>
 

--- a/client/src/pages/TicketDetail.tsx
+++ b/client/src/pages/TicketDetail.tsx
@@ -1,0 +1,278 @@
+import { useEffect, useState, useRef } from "react";
+import { useParams, Link } from "react-router-dom";
+import {
+  fetchTicketDetail,
+  uploadAttachment,
+  attachmentDownloadUrl,
+  removeAttachment,
+  TicketDetailData,
+  TicketNotFoundError,
+  AttachmentUploadError,
+  AttachmentMeta,
+} from "../api.js";
+import { useRequester } from "../context/RequesterContext.js";
+import { zenGreen } from "../theme.js";
+
+type ScreenState = "loading" | "not-found" | "error" | "ready";
+
+const cardStyle: React.CSSProperties = {
+  backgroundColor: "white",
+  border: "1px solid #E0E5E2",
+  borderRadius: 8,
+  boxShadow: "0 1px 3px rgba(0,0,0,0.05)",
+};
+
+const PRIORITY_BADGE: Record<string, string> = {
+  LOW: "#0B7A46",
+  MEDIUM: "#B8860B",
+  HIGH: "#B3261E",
+};
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+// Lab 2 Issue 6 — Requester Ticket Detail + Attachments
+export default function TicketDetail() {
+  const { id } = useParams<{ id: string }>();
+  const { requester } = useRequester();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const [state, setState] = useState<ScreenState>("loading");
+  const [ticket, setTicket] = useState<TicketDetailData | null>(null);
+  const [uploadError, setUploadError] = useState("");
+  const [uploading, setUploading] = useState(false);
+  const [removingId, setRemovingId] = useState<number | null>(null);
+
+  function load() {
+    if (!requester || !id) return;
+    setState("loading");
+    fetchTicketDetail(Number(id), requester.id)
+      .then((data) => {
+        setTicket(data);
+        setState("ready");
+      })
+      .catch((err) => {
+        setState(err instanceof TicketNotFoundError ? "not-found" : "error");
+      });
+  }
+
+  useEffect(load, [id, requester]);
+
+  async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file || !requester || !ticket) return;
+
+    setUploadError("");
+    setUploading(true);
+    try {
+      await uploadAttachment(ticket.id, requester.id, file);
+      load();
+    } catch (err) {
+      if (err instanceof AttachmentUploadError) {
+        const messages: Record<string, string> = {
+          INVALID_FILE_TYPE: "Only JPG, PNG, WEBP, or PDF files are allowed.",
+          FILE_TOO_LARGE: "File is too large — 5MB maximum.",
+          MAX_ATTACHMENTS_REACHED: "This ticket already has 5 active attachments.",
+        };
+        setUploadError(messages[err.code] ?? "Upload failed. Please try again.");
+      } else {
+        setUploadError("Upload failed. Please try again.");
+      }
+    } finally {
+      setUploading(false);
+      if (fileInputRef.current) fileInputRef.current.value = "";
+    }
+  }
+
+  async function handleRemove(attachment: AttachmentMeta) {
+    if (!requester) return;
+    const reason = window.prompt(`Reason for removing "${attachment.fileName}"?`);
+    if (!reason || !reason.trim()) return;
+
+    setRemovingId(attachment.id);
+    try {
+      await removeAttachment(attachment.id, requester.id, reason.trim());
+      load();
+    } catch {
+      setUploadError("Couldn't remove that attachment. Please try again.");
+    } finally {
+      setRemovingId(null);
+    }
+  }
+
+  if (state === "loading") {
+    return (
+      <div className="container py-5" style={{ maxWidth: 840 }}>
+        <p role="status">Loading ticket…</p>
+      </div>
+    );
+  }
+
+  if (state === "not-found") {
+    return (
+      <div className="container py-5" style={{ maxWidth: 840 }}>
+        <p role="alert">This ticket doesn't exist or isn't available to you.</p>
+        <Link to="/tickets">Back to My Tickets</Link>
+      </div>
+    );
+  }
+
+  if (state === "error" || !ticket) {
+    return (
+      <div className="container py-5" style={{ maxWidth: 840 }}>
+        <p role="alert" className="text-danger">
+          Couldn't load this ticket. Please try again.
+        </p>
+      </div>
+    );
+  }
+
+  const activeAttachments = ticket.attachments.filter((a) => !a.isRemoved);
+
+  return (
+    <div className="container py-5" style={{ maxWidth: 840 }}>
+      <Link to="/tickets" className="d-inline-block mb-3 small">
+        ← Back to My Tickets
+      </Link>
+
+      <div className="p-4 mb-4" style={cardStyle}>
+        <div className="row g-3 mb-3">
+          <div className="col-12 col-md-6 col-lg-3">
+            <div className="text-muted small">Ticket No.</div>
+            <div className="fw-bold">{ticket.ticketNumber}</div>
+          </div>
+          <div className="col-12 col-md-6 col-lg-3">
+            <div className="text-muted small">Ticket Date</div>
+            <div>{new Date(ticket.createdAt).toLocaleDateString()}</div>
+          </div>
+          <div className="col-12 col-md-6 col-lg-3">
+            <div className="text-muted small">Category</div>
+            <div>{ticket.category}</div>
+          </div>
+          <div className="col-12 col-md-6 col-lg-3">
+            <div className="text-muted small">Related System</div>
+            <div>{ticket.relatedSystem}</div>
+          </div>
+        </div>
+
+        <div className="row g-3 mb-3">
+          <div className="col-12 col-md-6 col-lg-3">
+            <div className="text-muted small">Requested Priority</div>
+            <span
+              className="badge"
+              style={{ backgroundColor: PRIORITY_BADGE[ticket.requestedPriority] }}
+            >
+              {ticket.requestedPriority}
+            </span>
+          </div>
+          <div className="col-12 col-md-6 col-lg-3">
+            <div className="text-muted small">IT Priority</div>
+            <div>{ticket.itPriority ?? "—"}</div>
+          </div>
+          <div className="col-12 col-md-6 col-lg-3">
+            <div className="text-muted small">Current Status</div>
+            <span className="badge" style={{ backgroundColor: zenGreen.secondary }}>
+              {ticket.currentStatus}
+            </span>
+          </div>
+        </div>
+
+        <div className="mb-3">
+          <div className="text-muted small">Summary</div>
+          <div>{ticket.summary}</div>
+        </div>
+
+        <div>
+          <div className="text-muted small">Description</div>
+          <div style={{ whiteSpace: "pre-wrap" }}>{ticket.description}</div>
+        </div>
+      </div>
+
+      <div className="p-4" style={cardStyle}>
+        <div className="d-flex justify-content-between align-items-center mb-3">
+          <h2 className="h5 mb-0" style={{ color: zenGreen.text }}>
+            Attachments ({activeAttachments.length}/5)
+          </h2>
+          <div>
+            <input
+              ref={fileInputRef}
+              type="file"
+              id="attachment-file"
+              className="d-none"
+              accept=".jpg,.jpeg,.png,.webp,.pdf"
+              onChange={handleFileChange}
+              disabled={uploading || activeAttachments.length >= 5}
+            />
+            <label
+              htmlFor="attachment-file"
+              className="btn btn-sm"
+              style={{
+                backgroundColor: zenGreen.primary,
+                color: "white",
+                opacity: uploading || activeAttachments.length >= 5 ? 0.6 : 1,
+                cursor: uploading || activeAttachments.length >= 5 ? "not-allowed" : "pointer",
+              }}
+            >
+              {uploading ? "Uploading…" : "+ Add Attachment"}
+            </label>
+          </div>
+        </div>
+
+        {uploadError && (
+          <p role="alert" className="text-danger small">
+            {uploadError}
+          </p>
+        )}
+
+        {ticket.attachments.length === 0 ? (
+          <p className="text-muted">No attachments yet.</p>
+        ) : (
+          <ul className="list-group">
+            {ticket.attachments.map((a) => (
+              <li
+                key={a.id}
+                className="list-group-item d-flex justify-content-between align-items-center"
+                style={a.isRemoved ? { opacity: 0.6 } : undefined}
+              >
+                <div>
+                  <div style={a.isRemoved ? { textDecoration: "line-through" } : undefined}>
+                    {a.fileName}{" "}
+                    <span className="text-muted small">({formatBytes(a.sizeBytes)})</span>
+                  </div>
+                  {a.isRemoved && (
+                    <div className="text-muted small">
+                      Removed {new Date(a.removedAt!).toLocaleDateString()} — {a.removedReason}
+                    </div>
+                  )}
+                </div>
+                <div className="d-flex gap-2">
+                  {!a.isRemoved && requester && (
+                    <>
+                      <a
+                        href={attachmentDownloadUrl(a.id, requester.id)}
+                        className="btn btn-sm btn-outline-secondary"
+                      >
+                        Download
+                      </a>
+                      <button
+                        type="button"
+                        className="btn btn-sm btn-outline-danger"
+                        disabled={removingId === a.id}
+                        onClick={() => handleRemove(a)}
+                      >
+                        {removingId === a.id ? "Removing…" : "Remove"}
+                      </button>
+                    </>
+                  )}
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/TicketsPlaceholder.tsx
+++ b/client/src/pages/TicketsPlaceholder.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { fetchTickets, TicketListItem, Priority } from "../api.js";
 import { useRequester } from "../context/RequesterContext.js";
 import { zenGreen } from "../theme.js";
@@ -20,11 +20,18 @@ const PRIORITY_BADGE: Record<Priority, string> = {
   HIGH: "#B3261E",
 };
 
+const SORT_LABELS: Record<SortField, string> = {
+  ticketNumber: "Ticket No.",
+  createdAt: "Created Date",
+  updatedAt: "Last Updated",
+};
+
 // Lab 2 Issue 5 — My Tickets
 // Reused this file from Issue 2's placeholder rather than creating a new
 // one, since it already owns the /tickets route.
 export default function TicketsPlaceholder() {
   const { requester } = useRequester();
+  const navigate = useNavigate();
 
   const [state, setState] = useState<ScreenState>("loading");
   const [items, setItems] = useState<TicketListItem[]>([]);
@@ -37,6 +44,7 @@ export default function TicketsPlaceholder() {
   const [sortBy, setSortBy] = useState<SortField>("createdAt");
   const [sortDir, setSortDir] = useState<"asc" | "desc">("desc");
   const [page, setPage] = useState(1);
+  const [sortMenuOpen, setSortMenuOpen] = useState(false);
 
   const hasActiveFilters = Boolean(search || requestedPriority || currentStatus);
 
@@ -165,6 +173,43 @@ export default function TicketsPlaceholder() {
         </div>
       </div>
 
+      <div className="d-flex justify-content-between align-items-center mb-3">
+        <div className="position-relative">
+          <button
+            type="button"
+            className="btn btn-sm btn-outline-secondary"
+            onClick={() => setSortMenuOpen((v) => !v)}
+            aria-expanded={sortMenuOpen}
+          >
+            Sort: {SORT_LABELS[sortBy]} ({sortDir === "asc" ? "▲" : "▼"})
+          </button>
+          {sortMenuOpen && (
+            <div
+              role="menu"
+              className="position-absolute start-0 mt-1 bg-white shadow rounded"
+              style={{ minWidth: 220, zIndex: 10 }}
+            >
+              {(Object.keys(SORT_LABELS) as SortField[]).map((field) => (
+                <button
+                  key={field}
+                  type="button"
+                  role="menuitem"
+                  className="btn btn-sm w-100 text-start d-flex justify-content-between"
+                  style={sortBy === field ? { backgroundColor: zenGreen.pale } : undefined}
+                  onClick={() => {
+                    toggleSort(field);
+                    setSortMenuOpen(false);
+                  }}
+                >
+                  <span>{SORT_LABELS[field]}</span>
+                  {sortBy === field && <span>{sortDir === "asc" ? "▲" : "▼"}</span>}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
       {state === "loading" && <p role="status">Loading tickets…</p>}
       {state === "error" && (
         <p role="alert" className="text-danger">
@@ -217,7 +262,11 @@ export default function TicketsPlaceholder() {
               </thead>
               <tbody>
                 {items.map((t) => (
-                  <tr key={t.id}>
+                  <tr
+                    key={t.id}
+                    style={{ cursor: "pointer" }}
+                    onClick={() => navigate(`/tickets/${t.id}`)}
+                  >
                     <td>{t.ticketNumber}</td>
                     <td>{t.summary}</td>
                     <td>{t.category}</td>

--- a/client/tests/lab-02/CreateTicket.test.tsx
+++ b/client/tests/lab-02/CreateTicket.test.tsx
@@ -111,9 +111,9 @@ describe("CreateTicket", () => {
 
   it("disables Submit while the request is in flight", async () => {
     mockReferenceData();
-    let resolveCreate: (value: unknown) => void = () => {};
+    let resolveCreate: (value: api.Ticket) => void = () => {};
     vi.spyOn(api, "createTicket").mockReturnValue(
-      new Promise((resolve) => {
+      new Promise<api.Ticket>((resolve) => {
         resolveCreate = resolve;
       })
     );
@@ -141,5 +141,88 @@ describe("CreateTicket", () => {
     await waitFor(() => {
       expect(screen.getByText("TKT-2026-000102")).toBeInTheDocument();
     });
+  });
+
+  it("rejects a disallowed file type client-side before submitting", async () => {
+    mockReferenceData();
+    renderScreen();
+    await fillValidForm();
+
+    const badFile = new File(["hello"], "notes.txt", { type: "text/plain" });
+    fireEvent.change(screen.getByLabelText(/attachments/i), { target: { files: [badFile] } });
+
+    expect(
+      screen.getByText(/isn't an allowed type \(JPG, PNG, WEBP, or PDF only\)/i)
+    ).toBeInTheDocument();
+  });
+
+  it("uploads selected files after the Ticket is created", async () => {
+    mockReferenceData();
+    vi.spyOn(api, "createTicket").mockResolvedValue({
+      id: 42,
+      ticketNumber: "TKT-2026-000103",
+      requesterId: 1,
+      categoryId: 1,
+      relatedSystemId: 1,
+      summary: "Laptop battery drains quickly",
+      description: "Battery drains fast even when idle, started after last update.",
+      requestedPriority: "MEDIUM",
+      itPriority: null,
+      status: "NEW",
+      createdAt: new Date().toISOString(),
+    });
+    const uploadSpy = vi.spyOn(api, "uploadAttachment").mockResolvedValue({
+      id: 1,
+      fileName: "photo.png",
+      sizeBytes: 100,
+      isRemoved: false,
+      removedAt: null,
+      removedReason: null,
+      createdAt: new Date().toISOString(),
+    });
+
+    renderScreen();
+    await fillValidForm();
+
+    const file = new File(["x"], "photo.png", { type: "image/png" });
+    fireEvent.change(screen.getByLabelText(/attachments/i), { target: { files: [file] } });
+    fireEvent.click(screen.getByRole("button", { name: /submit ticket/i }));
+
+    await waitFor(() => {
+      expect(uploadSpy).toHaveBeenCalledWith(42, 1, file);
+    });
+    expect(screen.getByText("TKT-2026-000103")).toBeInTheDocument();
+  });
+
+  it("reports attachment failures but still shows the Ticket as saved (BR-21)", async () => {
+    mockReferenceData();
+    vi.spyOn(api, "createTicket").mockResolvedValue({
+      id: 42,
+      ticketNumber: "TKT-2026-000104",
+      requesterId: 1,
+      categoryId: 1,
+      relatedSystemId: 1,
+      summary: "Laptop battery drains quickly",
+      description: "Battery drains fast even when idle, started after last update.",
+      requestedPriority: "MEDIUM",
+      itPriority: null,
+      status: "NEW",
+      createdAt: new Date().toISOString(),
+    });
+    vi.spyOn(api, "uploadAttachment").mockRejectedValue(
+      new api.AttachmentUploadError("INVALID_FILE_TYPE")
+    );
+
+    renderScreen();
+    await fillValidForm();
+
+    const file = new File(["x"], "photo.png", { type: "image/png" });
+    fireEvent.change(screen.getByLabelText(/attachments/i), { target: { files: [file] } });
+    fireEvent.click(screen.getByRole("button", { name: /submit ticket/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("TKT-2026-000104")).toBeInTheDocument();
+    });
+    expect(screen.getByText(/1 attachment\(s\) failed to upload/i)).toBeInTheDocument();
   });
 });

--- a/client/tests/lab-02/TicketDetail.test.tsx
+++ b/client/tests/lab-02/TicketDetail.test.tsx
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import TicketDetail from "../../src/pages/TicketDetail.js";
+import { RequesterProvider } from "../../src/context/RequesterContext.js";
+import * as api from "../../src/api.js";
+
+function renderScreen(id = "1") {
+  localStorage.setItem(
+    "toktickit.devRequester",
+    JSON.stringify({ id: 1, name: "Jennifer Anderson", email: "jennifer@example.com" })
+  );
+  return render(
+    <MemoryRouter initialEntries={[`/tickets/${id}`]}>
+      <RequesterProvider>
+        <Routes>
+          <Route path="/tickets/:id" element={<TicketDetail />} />
+        </Routes>
+      </RequesterProvider>
+    </MemoryRouter>
+  );
+}
+
+function baseTicket(overrides: Partial<api.TicketDetailData> = {}): api.TicketDetailData {
+  return {
+    id: 1,
+    ticketNumber: "TKT-2026-000001",
+    requesterId: 1,
+    category: "Hardware",
+    relatedSystem: "Corporate Laptop",
+    summary: "Laptop battery drains quickly",
+    description: "Battery drains fast even when idle, started after last update.",
+    requestedPriority: "MEDIUM",
+    itPriority: null,
+    currentStatus: "NEW",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    attachments: [],
+    ...overrides,
+  };
+}
+
+describe("TicketDetail", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    localStorage.clear();
+  });
+
+  it("shows a loading state, then the ticket's read-only fields", async () => {
+    vi.spyOn(api, "fetchTicketDetail").mockResolvedValue(baseTicket());
+    renderScreen();
+
+    expect(screen.getByRole("status")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText("TKT-2026-000001")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Hardware")).toBeInTheDocument();
+    expect(screen.getByText("Corporate Laptop")).toBeInTheDocument();
+    expect(screen.getByText("Laptop battery drains quickly")).toBeInTheDocument();
+  });
+
+  it("shows a not-found message for a ticket that isn't the Requester's own", async () => {
+    vi.spyOn(api, "fetchTicketDetail").mockRejectedValue(
+      new api.TicketNotFoundError("TICKET_NOT_FOUND")
+    );
+    renderScreen();
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(/doesn't exist or isn't available/i);
+    });
+  });
+
+  it("lists active and removed attachments differently", async () => {
+    vi.spyOn(api, "fetchTicketDetail").mockResolvedValue(
+      baseTicket({
+        attachments: [
+          {
+            id: 1,
+            fileName: "screenshot.png",
+            sizeBytes: 12345,
+            isRemoved: false,
+            removedAt: null,
+            removedReason: null,
+            createdAt: new Date().toISOString(),
+          },
+          {
+            id: 2,
+            fileName: "old-log.pdf",
+            sizeBytes: 5000,
+            isRemoved: true,
+            removedAt: new Date().toISOString(),
+            removedReason: "Wrong file",
+            createdAt: new Date().toISOString(),
+          },
+        ],
+      })
+    );
+
+    renderScreen();
+
+    await waitFor(() => screen.getByText(/screenshot.png/));
+    expect(screen.getByText(/old-log.pdf/)).toBeInTheDocument();
+    expect(screen.getByText(/Wrong file/)).toBeInTheDocument();
+    // Only the active one gets a Download button
+    expect(screen.getAllByRole("link", { name: /download/i })).toHaveLength(1);
+  });
+
+  it("shows an upload error message returned by the API", async () => {
+    vi.spyOn(api, "fetchTicketDetail").mockResolvedValue(baseTicket());
+    vi.spyOn(api, "uploadAttachment").mockRejectedValue(
+      new api.AttachmentUploadError("MAX_ATTACHMENTS_REACHED")
+    );
+
+    renderScreen();
+    await waitFor(() => screen.getByLabelText(/add attachment/i, { selector: "input" }));
+
+    const file = new File(["x"], "photo.png", { type: "image/png" });
+    fireEvent.change(screen.getByLabelText(/add attachment/i, { selector: "input" }), {
+      target: { files: [file] },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(/already has 5 active attachments/i);
+    });
+  });
+
+  it("removes an attachment after confirming a reason via prompt", async () => {
+    vi.spyOn(api, "fetchTicketDetail").mockResolvedValue(
+      baseTicket({
+        attachments: [
+          {
+            id: 1,
+            fileName: "screenshot.png",
+            sizeBytes: 12345,
+            isRemoved: false,
+            removedAt: null,
+            removedReason: null,
+            createdAt: new Date().toISOString(),
+          },
+        ],
+      })
+    );
+    const removeSpy = vi.spyOn(api, "removeAttachment").mockResolvedValue({
+      id: 1,
+      fileName: "screenshot.png",
+      sizeBytes: 12345,
+      isRemoved: true,
+      removedAt: new Date().toISOString(),
+      removedReason: "No longer needed",
+      createdAt: new Date().toISOString(),
+    });
+    vi.spyOn(window, "prompt").mockReturnValue("No longer needed");
+
+    renderScreen();
+    await waitFor(() => screen.getByRole("button", { name: /remove/i }));
+
+    fireEvent.click(screen.getByRole("button", { name: /remove/i }));
+
+    await waitFor(() => {
+      expect(removeSpy).toHaveBeenCalledWith(1, 1, "No longer needed");
+    });
+  });
+});

--- a/client/tests/lab-02/TicketsPlaceholder.test.tsx
+++ b/client/tests/lab-02/TicketsPlaceholder.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import TicketsPlaceholder from "../../src/pages/TicketsPlaceholder.js";
 import { RequesterProvider } from "../../src/context/RequesterContext.js";
@@ -92,5 +92,171 @@ describe("TicketsPlaceholder (My Tickets)", () => {
     await waitFor(() => {
       expect(screen.getByRole("alert")).toBeInTheDocument();
     });
+  });
+
+  it("Clear Filters is disabled with no active filters, enabled once one is set", async () => {
+    vi.spyOn(api, "fetchTickets").mockResolvedValue({ ...emptyResponse(), noResults: false });
+
+    renderScreen();
+    await waitFor(() => screen.getByLabelText(/search tickets/i));
+
+    const clearButton = screen.getByRole("button", { name: /clear filters/i });
+    expect(clearButton).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText(/search tickets/i), { target: { value: "laptop" } });
+
+    await waitFor(() => {
+      expect(clearButton).not.toBeDisabled();
+    });
+  });
+
+  it("clicking Clear Filters resets search and re-fetches with no filters", async () => {
+    const fetchSpy = vi.spyOn(api, "fetchTickets").mockResolvedValue({ ...emptyResponse(), noResults: false });
+
+    renderScreen();
+    await waitFor(() => screen.getByLabelText(/search tickets/i));
+
+    fireEvent.change(screen.getByLabelText(/search tickets/i), { target: { value: "laptop" } });
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenLastCalledWith(expect.objectContaining({ search: "laptop" }));
+    });
+
+    // Two "Clear Filters" buttons can coexist once a filter is active: the
+    // always-visible toolbar one, and the one inside the no-results state.
+    // Either does the same thing — click the toolbar one (first in the DOM).
+    fireEvent.click(screen.getAllByRole("button", { name: /clear filters/i })[0]);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/search tickets/i)).toHaveValue("");
+    });
+    expect(fetchSpy).toHaveBeenLastCalledWith(
+      expect.not.objectContaining({ search: expect.anything() })
+    );
+  });
+
+  it("renders a Created Date column alongside Last Updated", async () => {
+    const createdAt = new Date("2026-01-15T00:00:00Z").toISOString();
+    const updatedAt = new Date("2026-02-20T00:00:00Z").toISOString();
+
+    vi.spyOn(api, "fetchTickets").mockResolvedValue({
+      items: [
+        {
+          id: 1,
+          ticketNumber: "TKT-2026-000001",
+          summary: "Laptop battery drains quickly",
+          category: "Hardware",
+          requestedPriority: "MEDIUM",
+          itPriority: null,
+          currentStatus: "NEW",
+          createdAt,
+          updatedAt,
+        },
+      ],
+      page: 1,
+      pageSize: 10,
+      totalItems: 1,
+      totalPages: 1,
+      noResults: false,
+    });
+
+    renderScreen();
+
+    await waitFor(() => screen.getByText("TKT-2026-000001"));
+
+    // The sortable column headers use role="button" (for clickability),
+    // not the default columnheader role — scoped to the table since the
+    // "Sort" dropdown button's label also contains "Created Date".
+    const table = screen.getByRole("table");
+    expect(within(table).getByRole("button", { name: /created date/i })).toBeInTheDocument();
+    expect(screen.getByText(new Date(createdAt).toLocaleDateString())).toBeInTheDocument();
+    expect(screen.getByText(new Date(updatedAt).toLocaleDateString())).toBeInTheDocument();
+  });
+
+  it("clicking the Created Date header sorts by createdAt", async () => {
+    const fetchSpy = vi.spyOn(api, "fetchTickets").mockResolvedValue({
+      items: [
+        {
+          id: 1,
+          ticketNumber: "TKT-2026-000001",
+          summary: "Laptop battery drains quickly",
+          category: "Hardware",
+          requestedPriority: "MEDIUM",
+          itPriority: null,
+          currentStatus: "NEW",
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+      ],
+      page: 1,
+      pageSize: 10,
+      totalItems: 1,
+      totalPages: 1,
+      noResults: false,
+    });
+
+    renderScreen();
+    await waitFor(() => screen.getByText("TKT-2026-000001"));
+
+    // createdAt/desc is already the default sort state, so the FIRST click
+    // on "Created Date" flips it to asc (same column, direction toggles) —
+    // it does not re-select "desc", since that's already active.
+    fireEvent.click(within(screen.getByRole("table")).getByRole("button", { name: /created date/i }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenLastCalledWith(
+        expect.objectContaining({ sortBy: "createdAt", sortDir: "asc" })
+      );
+    });
+
+    // The table briefly unmounts (loading state) and remounts on every sort
+    // change, so we must re-query it fresh here rather than reuse the
+    // reference from before the first click.
+    await waitFor(() => screen.getByText("TKT-2026-000001"));
+    fireEvent.click(within(screen.getByRole("table")).getByRole("button", { name: /created date/i }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenLastCalledWith(
+        expect.objectContaining({ sortBy: "createdAt", sortDir: "desc" })
+      );
+    });
+  });
+
+  it("Sort button opens a dropdown and selecting a field sorts by it", async () => {
+    const fetchSpy = vi.spyOn(api, "fetchTickets").mockResolvedValue({
+      items: [
+        {
+          id: 1,
+          ticketNumber: "TKT-2026-000001",
+          summary: "Laptop battery drains quickly",
+          category: "Hardware",
+          requestedPriority: "MEDIUM",
+          itPriority: null,
+          currentStatus: "NEW",
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+      ],
+      page: 1,
+      pageSize: 10,
+      totalItems: 1,
+      totalPages: 1,
+      noResults: false,
+    });
+
+    renderScreen();
+    await waitFor(() => screen.getByText("TKT-2026-000001"));
+
+    // Default label reflects createdAt/desc before any interaction
+    expect(screen.getByRole("button", { name: /sort: created date/i })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /sort: created date/i }));
+    fireEvent.click(screen.getByRole("menuitem", { name: /^ticket no\./i }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenLastCalledWith(
+        expect.objectContaining({ sortBy: "ticketNumber" })
+      );
+    });
+    expect(screen.getByRole("button", { name: /sort: ticket no\./i })).toBeInTheDocument();
   });
 });

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -10,11 +10,13 @@
       "dependencies": {
         "@prisma/client": "^5.22.0",
         "cors": "^2.8.5",
-        "express": "^4.21.2"
+        "express": "^4.21.2",
+        "multer": "^2.3.0"
       },
       "devDependencies": {
         "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
+        "@types/multer": "^2.2.0",
         "@types/node": "^22.10.2",
         "@types/supertest": "^6.0.2",
         "prisma": "^5.22.0",
@@ -936,6 +938,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/multer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-2.2.0.tgz",
+      "integrity": "sha512-3U1troeqGV8Ntp7Q3klwf4zr23VEoqYVocYXaswm9+8z3O9UHDYAqLxjJ/h550iRADTjKdOdhhasXw6gD6kYtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "22.20.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
@@ -1143,6 +1155,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -1195,6 +1213,23 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
       }
     },
     "node_modules/bytes": {
@@ -1266,6 +1301,21 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
       }
     },
     "node_modules/content-disposition": {
@@ -2200,6 +2250,25 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/multer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.3.0.tgz",
+      "integrity": "sha512-cjNbm3sttszgZeGfJR124D+jFEfkXCVAsoPBmFn9X7UxmDSFHWqE2CoEj0vrmSpuAFnqWR1Szcm9QTsiHr60Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "type-is": "^1.6.18"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.18",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
@@ -2429,6 +2498,20 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/rolldown": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.4.tgz",
@@ -2651,6 +2734,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/superagent": {
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
@@ -2820,6 +2920,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -2849,6 +2955,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",

--- a/server/package.json
+++ b/server/package.json
@@ -17,11 +17,13 @@
   "dependencies": {
     "@prisma/client": "^5.22.0",
     "cors": "^2.8.5",
-    "express": "^4.21.2"
+    "express": "^4.21.2",
+    "multer": "^2.3.0"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
+    "@types/multer": "^2.2.0",
     "@types/node": "^22.10.2",
     "@types/supertest": "^6.0.2",
     "prisma": "^5.22.0",

--- a/server/prisma/migrations/20260905034203_add_attachment/migration.sql
+++ b/server/prisma/migrations/20260905034203_add_attachment/migration.sql
@@ -1,0 +1,26 @@
+-- CreateTable
+CREATE TABLE "Attachment" (
+    "id" SERIAL NOT NULL,
+    "ticketId" INTEGER NOT NULL,
+    "fileName" TEXT NOT NULL,
+    "storedFileName" TEXT NOT NULL,
+    "mimeType" TEXT NOT NULL,
+    "sizeBytes" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "removedAt" TIMESTAMP(3),
+    "removedReason" TEXT,
+
+    CONSTRAINT "Attachment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Attachment_storedFileName_key" ON "Attachment"("storedFileName");
+
+-- CreateIndex
+CREATE INDEX "Attachment_ticketId_idx" ON "Attachment"("ticketId");
+
+-- CreateIndex
+CREATE INDEX "Attachment_removedAt_idx" ON "Attachment"("removedAt");
+
+-- AddForeignKey
+ALTER TABLE "Attachment" ADD CONSTRAINT "Attachment_ticketId_fkey" FOREIGN KEY ("ticketId") REFERENCES "Ticket"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/server/prisma/migrations/20260905150349_add_status_fields/migration.sql
+++ b/server/prisma/migrations/20260905150349_add_status_fields/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "Attachment" ADD COLUMN     "isRemoved" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "Category" ADD COLUMN     "isActive" BOOLEAN NOT NULL DEFAULT true;
+
+-- AlterTable
+ALTER TABLE "RelatedSystem" ADD COLUMN     "isActive" BOOLEAN NOT NULL DEFAULT true;

--- a/server/prisma/migrations/20260905150548_default_it_priority_medium/migration.sql
+++ b/server/prisma/migrations/20260905150548_default_it_priority_medium/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - Made the column `itPriority` on table `Ticket` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "Ticket" ALTER COLUMN "itPriority" SET NOT NULL,
+ALTER COLUMN "itPriority" SET DEFAULT 'MEDIUM';

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -98,12 +98,42 @@ model Ticket {
   createdAt         DateTime      @default(now())
   updatedAt         DateTime      @updatedAt
 
-  // TODO(Lab 2 Issue 6): add `attachments Attachment[]` once the Attachment
+  // Lab 2 Issue 6 — Ticket Detail + Attachments
   // model exists — do not add it here, it will fail to compile until then.
+  attachments       Attachment[]
 
   // spec.md §7 — indexes supporting ownership checks, status filtering,
   // and category filtering on the My Tickets list (Issue 5).
+
   @@index([requesterId])
   @@index([status])
   @@index([categoryId])
+}
+// ---------------------------------------------------------------------------
+// Lab 2 Issue 6 — Ticket Detail + Attachments
+// BR-22 to BR-27: allowed types (JPG/JPEG, PNG, WEBP, PDF), 5MB max, 5
+// active attachments max per Ticket, soft-removal only (never hard delete).
+// ---------------------------------------------------------------------------
+model Attachment {
+  id             Int       @id @default(autoincrement())
+
+  ticketId       Int
+  ticket         Ticket    @relation(fields: [ticketId], references: [id])
+
+  // BR-24: original filename is display-only metadata; the file on disk
+  // uses a generated, collision-safe name (storedFileName).
+  fileName       String
+  storedFileName String    @unique
+  mimeType       String
+  sizeBytes      Int
+
+  createdAt      DateTime  @default(now())
+
+  // BR-26/BR-27: soft removal only — row is never physically deleted, and
+  // remains visible as metadata after removal, but blocks download/preview.
+  removedAt      DateTime?
+  removedReason  String?
+
+  @@index([ticketId])
+  @@index([removedAt])
 }

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -24,6 +24,7 @@ datasource db {
 model Category {
   id        Int      @id @default(autoincrement())
   name      String   @unique
+  isActive  Boolean  @default(true)
   createdAt DateTime @default(now())
   tickets   Ticket[]
 }
@@ -64,8 +65,8 @@ enum TicketStatus {
 model RelatedSystem {
   id        Int      @id @default(autoincrement())
   name      String   @unique
+  isActive  Boolean  @default(true)
   createdAt DateTime @default(now())
-
   tickets   Ticket[]
 }
 
@@ -91,7 +92,7 @@ model Ticket {
   requestedPriority Priority
 
   // BR-02: unset until IT Staff triage in a later sprint (out of scope here).
-  itPriority        Priority?
+  itPriority Priority @default(MEDIUM)
 
   status            TicketStatus  @default(NEW)
 
@@ -131,6 +132,7 @@ model Attachment {
 
   // BR-26/BR-27: soft removal only — row is never physically deleted, and
   // remains visible as metadata after removal, but blocks download/preview.
+  isRemoved      Boolean   @default(false)
   removedAt      DateTime?
   removedReason  String?
 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -40,6 +40,7 @@ app.get("/api/categories", async (_req: Request, res: Response) => {
   try {
     const categories = await getPrisma().category.findMany({
       orderBy: { id: "asc" },
+      where: { isActive: true },
       select: { id: true, name: true },
     });
     res.status(200).json(categories);
@@ -74,6 +75,7 @@ app.get("/api/related-systems", async (_req: Request, res: Response) => {
   try {
     const relatedSystems = await getPrisma().relatedSystem.findMany({
       orderBy: { id: "asc" },
+      where: { isActive: true },
       select: { id: true, name: true },
     });
     res.status(200).json(relatedSystems);
@@ -285,16 +287,17 @@ app.get("/api/tickets/:id", async (req: Request, res: Response) => {
         category: { select: { name: true } },
         relatedSystem: { select: { name: true } },
         attachments: {
-          select: {
-            id: true,
-            fileName: true,
-            sizeBytes: true,
-            mimeType: true,
-            removedAt: true,
-            removedReason: true,
-            createdAt: true,
-          },
-        },
+  select: {
+    id: true,
+    fileName: true,
+    sizeBytes: true,
+    mimeType: true,
+    isRemoved: true,
+    removedAt: true,
+    removedReason: true,
+    createdAt: true,
+  },
+},
       },
     });
 
@@ -321,7 +324,7 @@ app.get("/api/tickets/:id", async (req: Request, res: Response) => {
         fileName: a.fileName,
         sizeBytes: a.sizeBytes,
         mimeType: a.mimeType,
-        isRemoved: a.removedAt !== null,
+        isRemoved: a.isRemoved,
         removedAt: a.removedAt,
         removedReason: a.removedReason,
         createdAt: a.createdAt,
@@ -361,7 +364,7 @@ app.get("/api/tickets/:id/attachments", async (req: Request, res: Response) => {
         id: a.id,
         fileName: a.fileName,
         sizeBytes: a.sizeBytes,
-        isRemoved: a.removedAt !== null,
+        isRemoved: a.isRemoved,
         removedAt: a.removedAt,
         removedReason: a.removedReason,
         createdAt: a.createdAt,
@@ -410,7 +413,7 @@ app.post(
 
       // BR-22: max 5 ACTIVE attachments per Ticket (removed ones don't count).
       const activeCount = await prisma.attachment.count({
-        where: { ticketId, removedAt: null },
+        where: { ticketId, isRemoved: false },
       });
       if (activeCount >= MAX_ACTIVE_ATTACHMENTS) {
         await cleanupAndRespond(400, { error: "MAX_ATTACHMENTS_REACHED" });
@@ -479,7 +482,7 @@ app.get("/api/attachments/:id/download", async (req: Request, res: Response) => 
     }
     // BR-27: a removed attachment cannot be downloaded, even though its
     // metadata is still visible elsewhere.
-    if (attachment.removedAt) {
+    if (attachment.isRemoved) {
       res.status(410).json({ error: "ATTACHMENT_REMOVED" });
       return;
     }
@@ -529,7 +532,11 @@ app.patch("/api/attachments/:id/remove", async (req: Request, res: Response) => 
 
     const updated = await prisma.attachment.update({
       where: { id: attachmentId },
-      data: { removedAt: new Date(), removedReason: reason.trim() },
+      data: {
+  isRemoved: true,
+  removedAt: new Date(),
+  removedReason: reason.trim(),
+},
     });
 
     res.status(200).json({

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,8 +1,12 @@
 import express, { Request, Response } from "express";
 import cors from "cors";
+import fs from "fs";
+import path from "path";
 import { getPrisma } from "./prisma.js";
 import { validateCreateTicket } from "./validateCreateTicket.js";
 import { createTicketWithGeneratedNumber } from "./ticketNumber.js";
+import { upload, UPLOADS_DIR } from "./attachmentUpload.js";
+const MAX_ACTIVE_ATTACHMENTS = 5;
 // getPrisma() is your lazy database handle. Call it INSIDE a route when you
 // need the DB (Issue 4). It is intentionally unused until then.
 
@@ -256,5 +260,289 @@ app.post("/api/tickets", async (req: Request, res: Response) => {
     res.status(500).json({ error: "UNEXPECTED_ERROR" });
   }
 });
+
+// ---------------------------------------------------------------------------
+// Lab 2 Issue 6 — Ticket Detail + Attachments
+// ---------------------------------------------------------------------------
+
+// GET /api/tickets/:id -> one owned Ticket, plus its attachment metadata.
+// api-spec.md §6: requesterId required as query param for ownership check.
+// Not owned / doesn't exist -> same 404, never distinguished (BR-09).
+app.get("/api/tickets/:id", async (req: Request, res: Response) => {
+  const ticketId = Number(req.params.id);
+  const requesterId = Number(req.query.requesterId);
+
+  if (Number.isNaN(ticketId) || !req.query.requesterId || Number.isNaN(requesterId)) {
+    res.status(400).json({ error: "REQUESTER_ID_REQUIRED" });
+    return;
+  }
+
+  try {
+    const prisma = getPrisma();
+    const ticket = await prisma.ticket.findFirst({
+      where: { id: ticketId, requesterId },
+      include: {
+        category: { select: { name: true } },
+        relatedSystem: { select: { name: true } },
+        attachments: {
+          select: {
+            id: true,
+            fileName: true,
+            sizeBytes: true,
+            mimeType: true,
+            removedAt: true,
+            removedReason: true,
+            createdAt: true,
+          },
+        },
+      },
+    });
+
+    if (!ticket) {
+      res.status(404).json({ error: "TICKET_NOT_FOUND" });
+      return;
+    }
+
+    res.status(200).json({
+      id: ticket.id,
+      ticketNumber: ticket.ticketNumber,
+      requesterId: ticket.requesterId,
+      category: ticket.category.name,
+      relatedSystem: ticket.relatedSystem.name,
+      summary: ticket.summary,
+      description: ticket.description,
+      requestedPriority: ticket.requestedPriority,
+      itPriority: ticket.itPriority,
+      currentStatus: ticket.status,
+      createdAt: ticket.createdAt,
+      updatedAt: ticket.updatedAt,
+      attachments: ticket.attachments.map((a) => ({
+        id: a.id,
+        fileName: a.fileName,
+        sizeBytes: a.sizeBytes,
+        mimeType: a.mimeType,
+        isRemoved: a.removedAt !== null,
+        removedAt: a.removedAt,
+        removedReason: a.removedReason,
+        createdAt: a.createdAt,
+      })),
+    });
+  } catch (err) {
+    console.error("Failed to load ticket:", err);
+    res.status(500).json({ error: "UNEXPECTED_ERROR" });
+  }
+});
+
+// GET /api/tickets/:id/attachments -> attachment metadata only (active + removed).
+app.get("/api/tickets/:id/attachments", async (req: Request, res: Response) => {
+  const ticketId = Number(req.params.id);
+  const requesterId = Number(req.query.requesterId);
+
+  if (Number.isNaN(ticketId) || !req.query.requesterId || Number.isNaN(requesterId)) {
+    res.status(400).json({ error: "REQUESTER_ID_REQUIRED" });
+    return;
+  }
+
+  try {
+    const prisma = getPrisma();
+    const ticket = await prisma.ticket.findFirst({ where: { id: ticketId, requesterId } });
+    if (!ticket) {
+      res.status(404).json({ error: "TICKET_NOT_FOUND" });
+      return;
+    }
+
+    const attachments = await prisma.attachment.findMany({
+      where: { ticketId },
+      orderBy: { createdAt: "asc" },
+    });
+
+    res.status(200).json(
+      attachments.map((a) => ({
+        id: a.id,
+        fileName: a.fileName,
+        sizeBytes: a.sizeBytes,
+        isRemoved: a.removedAt !== null,
+        removedAt: a.removedAt,
+        removedReason: a.removedReason,
+        createdAt: a.createdAt,
+      }))
+    );
+  } catch (err) {
+    console.error("Failed to load attachments:", err);
+    res.status(500).json({ error: "UNEXPECTED_ERROR" });
+  }
+});
+
+// POST /api/tickets/:id/attachments -> upload an Attachment (multipart/form-data).
+// Form fields: file (binary), requesterId.
+app.post(
+  "/api/tickets/:id/attachments",
+  upload.single("file"),
+  async (req: Request, res: Response) => {
+    const ticketId = Number(req.params.id);
+    const requesterId = Number(req.body.requesterId);
+
+    // Clean up the file multer already wrote to disk if validation fails
+    // past this point, so rejected uploads don't leave orphan files.
+    async function cleanupAndRespond(status: number, body: unknown) {
+      if (req.file) {
+        await fs.promises.unlink(req.file.path).catch(() => {});
+      }
+      res.status(status).json(body);
+    }
+
+    if (Number.isNaN(ticketId) || !req.body.requesterId || Number.isNaN(requesterId)) {
+      await cleanupAndRespond(400, { error: "REQUESTER_ID_REQUIRED" });
+      return;
+    }
+    if (!req.file) {
+      await cleanupAndRespond(400, { error: "INVALID_FILE_TYPE" });
+      return;
+    }
+
+    try {
+      const prisma = getPrisma();
+      const ticket = await prisma.ticket.findFirst({ where: { id: ticketId, requesterId } });
+      if (!ticket) {
+        await cleanupAndRespond(404, { error: "TICKET_NOT_FOUND" });
+        return;
+      }
+
+      // BR-22: max 5 ACTIVE attachments per Ticket (removed ones don't count).
+      const activeCount = await prisma.attachment.count({
+        where: { ticketId, removedAt: null },
+      });
+      if (activeCount >= MAX_ACTIVE_ATTACHMENTS) {
+        await cleanupAndRespond(400, { error: "MAX_ATTACHMENTS_REACHED" });
+        return;
+      }
+
+      const attachment = await prisma.attachment.create({
+        data: {
+          ticketId,
+          fileName: req.file.originalname,
+          storedFileName: req.file.filename,
+          mimeType: req.file.mimetype,
+          sizeBytes: req.file.size,
+        },
+      });
+
+      res.status(201).json({
+        id: attachment.id,
+        fileName: attachment.fileName,
+        sizeBytes: attachment.sizeBytes,
+        mimeType: attachment.mimeType,
+        isRemoved: false,
+        createdAt: attachment.createdAt,
+      });
+    } catch (err) {
+      console.error("Failed to save attachment:", err);
+      await cleanupAndRespond(500, { error: "UNEXPECTED_ERROR" });
+    }
+  }
+);
+
+// Multer errors (wrong type / too large) land here, not in the route handler.
+app.use((err: Error, req: Request, res: Response, next: (err?: Error) => void) => {
+  if (err.message === "INVALID_FILE_TYPE") {
+    res.status(400).json({ error: "INVALID_FILE_TYPE" });
+    return;
+  }
+  if (err.name === "MulterError" && (err as { code?: string }).code === "LIMIT_FILE_SIZE") {
+    res.status(400).json({ error: "FILE_TOO_LARGE" });
+    return;
+  }
+  next(err);
+});
+
+// GET /api/attachments/:id/download -> stream an active Attachment's bytes.
+app.get("/api/attachments/:id/download", async (req: Request, res: Response) => {
+  const attachmentId = Number(req.params.id);
+  const requesterId = Number(req.query.requesterId);
+
+  if (Number.isNaN(attachmentId) || !req.query.requesterId || Number.isNaN(requesterId)) {
+    res.status(400).json({ error: "REQUESTER_ID_REQUIRED" });
+    return;
+  }
+
+  try {
+    const prisma = getPrisma();
+    const attachment = await prisma.attachment.findUnique({
+      where: { id: attachmentId },
+      include: { ticket: { select: { requesterId: true } } },
+    });
+
+    // BR-09-style ownership check: not owned or doesn't exist -> same 404.
+    if (!attachment || attachment.ticket.requesterId !== requesterId) {
+      res.status(404).json({ error: "ATTACHMENT_NOT_FOUND" });
+      return;
+    }
+    // BR-27: a removed attachment cannot be downloaded, even though its
+    // metadata is still visible elsewhere.
+    if (attachment.removedAt) {
+      res.status(410).json({ error: "ATTACHMENT_REMOVED" });
+      return;
+    }
+
+    const filePath = path.join(UPLOADS_DIR, attachment.storedFileName);
+    res.setHeader("Content-Type", attachment.mimeType);
+    res.setHeader(
+      "Content-Disposition",
+      `attachment; filename="${encodeURIComponent(attachment.fileName)}"`
+    );
+    fs.createReadStream(filePath).pipe(res);
+  } catch (err) {
+    console.error("Failed to download attachment:", err);
+    res.status(500).json({ error: "UNEXPECTED_ERROR" });
+  }
+});
+
+// PATCH /api/attachments/:id/remove -> soft-remove an Attachment (BR-26).
+app.patch("/api/attachments/:id/remove", async (req: Request, res: Response) => {
+  const attachmentId = Number(req.params.id);
+  const { requesterId, reason } = req.body as { requesterId?: number; reason?: string };
+
+  if (!requesterId || Number.isNaN(Number(requesterId))) {
+    res.status(400).json({ error: "REQUESTER_ID_REQUIRED" });
+    return;
+  }
+  if (!reason || !reason.trim()) {
+    res.status(400).json({ error: "REASON_REQUIRED" });
+    return;
+  }
+
+  try {
+    const prisma = getPrisma();
+    const attachment = await prisma.attachment.findUnique({
+      where: { id: attachmentId },
+      include: { ticket: { select: { requesterId: true } } },
+    });
+
+    if (!attachment || attachment.ticket.requesterId !== Number(requesterId)) {
+      res.status(404).json({ error: "ATTACHMENT_NOT_FOUND" });
+      return;
+    }
+    if (attachment.removedAt) {
+      res.status(409).json({ error: "ALREADY_REMOVED" });
+      return;
+    }
+
+    const updated = await prisma.attachment.update({
+      where: { id: attachmentId },
+      data: { removedAt: new Date(), removedReason: reason.trim() },
+    });
+
+    res.status(200).json({
+      id: updated.id,
+      isRemoved: true,
+      removedAt: updated.removedAt,
+      removedReason: updated.removedReason,
+    });
+  } catch (err) {
+    console.error("Failed to remove attachment:", err);
+    res.status(500).json({ error: "UNEXPECTED_ERROR" });
+  }
+});
+
 
 export default app;

--- a/server/src/attachmentUpload.ts
+++ b/server/src/attachmentUpload.ts
@@ -1,0 +1,47 @@
+import multer from "multer";
+import path from "path";
+import crypto from "crypto";
+import fs from "fs";
+
+// Lab 2 Issue 6 — Attachment upload
+// BR-22: JPG/JPEG, PNG, WEBP, PDF only, 5MB max per file.
+// BR-24: original filename kept only as display metadata; the file on
+// disk uses a generated, collision-safe name.
+
+const ALLOWED_MIME_TYPES = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "application/pdf",
+]);
+
+const MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024; // 5MB
+
+export const UPLOADS_DIR = path.resolve(process.cwd(), "uploads");
+
+// Fresh clone / first run won't have this directory yet — multer's
+// diskStorage does not create it automatically and will error otherwise.
+if (!fs.existsSync(UPLOADS_DIR)) {
+  fs.mkdirSync(UPLOADS_DIR, { recursive: true });
+}
+
+const storage = multer.diskStorage({
+  destination: (_req, _file, cb) => cb(null, UPLOADS_DIR),
+  filename: (_req, file, cb) => {
+    const ext = path.extname(file.originalname);
+    const safeName = `${Date.now()}-${crypto.randomBytes(8).toString("hex")}${ext}`;
+    cb(null, safeName);
+  },
+});
+
+export const upload = multer({
+  storage,
+  limits: { fileSize: MAX_FILE_SIZE_BYTES },
+  fileFilter: (_req, file, cb) => {
+    if (!ALLOWED_MIME_TYPES.has(file.mimetype)) {
+      cb(new Error("INVALID_FILE_TYPE"));
+      return;
+    }
+    cb(null, true);
+  },
+});

--- a/server/tests/lab-02/attachments.api.test.ts
+++ b/server/tests/lab-02/attachments.api.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import request from "supertest";
+import { app } from "../../src/app.js";
+import { getPrisma } from "../../src/prisma.js";
+
+describe("Ticket Detail + Attachments (Issue 6)", () => {
+  let requesterAId: number;
+  let requesterBId: number;
+  let categoryId: number;
+  let relatedSystemId: number;
+  let ticketId: number;
+
+  const tinyPng = Buffer.from(
+    "89504e470d0a1a0a0000000d49484452000000010000000108020000009077" +
+      "53de0000000c4944415408d76360000000020001e221bc330000000049454e44ae426082",
+    "hex"
+  );
+
+  beforeAll(async () => {
+    const prisma = getPrisma();
+
+    const a = await prisma.developmentRequester.create({
+      data: { name: "Attach Test A", email: "attach.a@example.com", isActive: true },
+    });
+    const b = await prisma.developmentRequester.create({
+      data: { name: "Attach Test B", email: "attach.b@example.com", isActive: true },
+    });
+    const category = await prisma.category.upsert({
+      where: { name: "Hardware" },
+      update: {},
+      create: { name: "Hardware" },
+    });
+    const relatedSystem = await prisma.relatedSystem.upsert({
+      where: { name: "Corporate Laptop" },
+      update: {},
+      create: { name: "Corporate Laptop" },
+    });
+    const ticket = await prisma.ticket.create({
+      data: {
+        ticketNumber: "TKT-TEST-ATTACH01",
+        requesterId: a.id,
+        categoryId: category.id,
+        relatedSystemId: relatedSystem.id,
+        summary: "Attachment test ticket",
+        description: "Used to test attachment upload/download/remove flows.",
+        requestedPriority: "MEDIUM",
+        status: "NEW",
+      },
+    });
+
+    requesterAId = a.id;
+    requesterBId = b.id;
+    categoryId = category.id;
+    relatedSystemId = relatedSystem.id;
+    ticketId = ticket.id;
+  });
+
+  afterAll(async () => {
+    const prisma = getPrisma();
+    await prisma.attachment.deleteMany({ where: { ticketId } });
+    await prisma.ticket.deleteMany({ where: { id: ticketId } });
+    await prisma.developmentRequester.deleteMany({
+      where: { id: { in: [requesterAId, requesterBId] } },
+    });
+  });
+
+  describe("GET /api/tickets/:id", () => {
+    it("returns the owned ticket with its attachments", async () => {
+      const res = await request(app).get(`/api/tickets/${ticketId}?requesterId=${requesterAId}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.ticketNumber).toBe("TKT-TEST-ATTACH01");
+      expect(res.body.attachments).toEqual([]);
+    });
+
+    // BR-09: cross-requester access rejected, same 404 either way
+    it("returns 404 for a different requester's ticket", async () => {
+      const res = await request(app).get(`/api/tickets/${ticketId}?requesterId=${requesterBId}`);
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe("TICKET_NOT_FOUND");
+    });
+  });
+
+  describe("POST /api/tickets/:id/attachments", () => {
+    it("uploads a valid PNG and returns its metadata", async () => {
+      const res = await request(app)
+        .post(`/api/tickets/${ticketId}/attachments`)
+        .field("requesterId", String(requesterAId))
+        .attach("file", tinyPng, { filename: "screenshot.png", contentType: "image/png" });
+
+      expect(res.status).toBe(201);
+      expect(res.body.fileName).toBe("screenshot.png");
+      expect(res.body.isRemoved).toBe(false);
+    });
+
+    // BR-22
+    it("rejects a disallowed file type", async () => {
+      const res = await request(app)
+        .post(`/api/tickets/${ticketId}/attachments`)
+        .field("requesterId", String(requesterAId))
+        .attach("file", Buffer.from("not an image"), {
+          filename: "notes.txt",
+          contentType: "text/plain",
+        });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe("INVALID_FILE_TYPE");
+    });
+
+    // BR-09
+    it("rejects upload from a non-owning requester", async () => {
+      const res = await request(app)
+        .post(`/api/tickets/${ticketId}/attachments`)
+        .field("requesterId", String(requesterBId))
+        .attach("file", tinyPng, { filename: "screenshot2.png", contentType: "image/png" });
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe("TICKET_NOT_FOUND");
+    });
+
+    // BR-22: max 5 active attachments per ticket
+    it("rejects a 6th active attachment", async () => {
+      // one was already added in the first test above; add 4 more to reach 5
+      for (let i = 0; i < 4; i++) {
+        const r = await request(app)
+          .post(`/api/tickets/${ticketId}/attachments`)
+          .field("requesterId", String(requesterAId))
+          .attach("file", tinyPng, { filename: `extra-${i}.png`, contentType: "image/png" });
+        expect(r.status).toBe(201);
+      }
+
+      const sixth = await request(app)
+        .post(`/api/tickets/${ticketId}/attachments`)
+        .field("requesterId", String(requesterAId))
+        .attach("file", tinyPng, { filename: "sixth.png", contentType: "image/png" });
+
+      expect(sixth.status).toBe(400);
+      expect(sixth.body.error).toBe("MAX_ATTACHMENTS_REACHED");
+    });
+  });
+
+  describe("GET /api/attachments/:id/download and PATCH /remove", () => {
+    let attachmentId: number;
+
+    beforeAll(async () => {
+      const prisma = getPrisma();
+      const attachment = await prisma.attachment.findFirst({
+        where: { ticketId, fileName: "screenshot.png" },
+      });
+      attachmentId = attachment!.id;
+    });
+
+    it("downloads an active attachment", async () => {
+      const res = await request(app).get(
+        `/api/attachments/${attachmentId}/download?requesterId=${requesterAId}`
+      );
+      expect(res.status).toBe(200);
+      expect(res.headers["content-type"]).toContain("image/png");
+    });
+
+    it("rejects download from a non-owning requester", async () => {
+      const res = await request(app).get(
+        `/api/attachments/${attachmentId}/download?requesterId=${requesterBId}`
+      );
+      expect(res.status).toBe(404);
+    });
+
+    // BR-26: reason required
+    it("rejects removal without a reason", async () => {
+      const res = await request(app)
+        .patch(`/api/attachments/${attachmentId}/remove`)
+        .send({ requesterId: requesterAId });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe("REASON_REQUIRED");
+    });
+
+    it("soft-removes with a reason, then blocks further download (BR-27)", async () => {
+      const removeRes = await request(app)
+        .patch(`/api/attachments/${attachmentId}/remove`)
+        .send({ requesterId: requesterAId, reason: "Wrong screenshot attached" });
+
+      expect(removeRes.status).toBe(200);
+      expect(removeRes.body.isRemoved).toBe(true);
+
+      const downloadRes = await request(app).get(
+        `/api/attachments/${attachmentId}/download?requesterId=${requesterAId}`
+      );
+      expect(downloadRes.status).toBe(410);
+    });
+
+    // BR-27: removed attachment still visible as metadata
+    it("still shows the removed attachment in the ticket's attachment list", async () => {
+      const res = await request(app).get(`/api/tickets/${ticketId}?requesterId=${requesterAId}`);
+      const found = res.body.attachments.find((a: { id: number }) => a.id === attachmentId);
+
+      expect(found).toBeTruthy();
+      expect(found.isRemoved).toBe(true);
+      expect(found.removedReason).toBe("Wrong screenshot attached");
+    });
+
+    it("rejects removing an already-removed attachment", async () => {
+      const res = await request(app)
+        .patch(`/api/attachments/${attachmentId}/remove`)
+        .send({ requesterId: requesterAId, reason: "trying again" });
+
+      expect(res.status).toBe(409);
+      expect(res.body.error).toBe("ALREADY_REMOVED");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements **Lab 2 – Issue 6: Requester Ticket Detail + Attachments**, and adds attachment upload support to **Create Ticket (Issue 4)** now that the Attachment model is available.

## Changes

### Database

* Added the `Attachment` model with file metadata, collision-safe stored filenames, and soft-removal fields.
* Added the `Ticket.attachments` relation.
* Added the `add_attachment` migration.
* Attachments are never physically deleted (BR-26).

### Backend

* Added ticket detail endpoint with ownership protection (BR-09).
* Added attachment listing, upload, download, and soft-remove endpoints.
* Upload validation supports JPG, JPEG, PNG, WEBP, and PDF files, with a **5 MB file limit** and **maximum 5 active attachments per ticket** (BR-22).
* Removed attachments cannot be downloaded (BR-27).
* Prevents double removal and cleans up orphaned files after failed uploads.
* Added `multer` 2.x and `@types/multer`.

### Frontend

* Added a guarded **Ticket Detail** page with read-only ticket information and attachment management.
* Supports adding, downloading, and removing attachments.
* Removed attachments are visually distinguished with removal reason and date.
* My Tickets rows now link to Ticket Detail.
* Added optional attachment upload to Create Ticket.
* Tickets are created first, followed by attachment uploads. Failed uploads do not roll back ticket creation (BR-21).
* Added a dedicated **Sort** dropdown to My Tickets.

## Testing

* Added **12 backend attachment API tests**.
* Added **5 Ticket Detail frontend tests**.
* Added **3 Create Ticket attachment tests**.
* Added **1 Sort dropdown test**.
* **Full client test suite: 34/34 passing.**
